### PR TITLE
Upgrading docker image for builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,8 +9,8 @@ pool:
 
 resources:
   containers:
-    - container: 'conan'
-      image: 'conanio/gcc11-ubuntu16.04'
+    - container: 'ubuntu18.04-gcc11-conan2'
+      image: 'mattgomes28/cpp-ubuntu-bionic:0.1'
       options: '--user 0:0'
 
 stages:
@@ -19,7 +19,7 @@ stages:
   displayName: 'Build Project'
   jobs:
   - job: 'build_x86_64'  
-    container: 'conan'
+    container: 'ubuntu18.04-gcc11-conan2'
     continueOnError: 'false'
     steps:
       - bash: scripts/helpers/conan-install.sh
@@ -43,7 +43,7 @@ stages:
   displayName: 'Running Tests'
   jobs:
   - job:
-    container: 'conan'
+    container: 'ubuntu18.04-gcc11-conan2'
     steps:
       - checkout: none
       - task: DownloadPipelineArtifact@2

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,14 +25,13 @@ RUN apt-get update \
     python3 \
     python3-pip \
     && mkdir "/conan" \
+    && pip3 install --upgrade --no-cache pip \
     && pip3 install --no-cache -q conan==2.0.1 \
     && chmod -R 777 "/conan" \
     && pip3 install --no-cache cmake==3.25.2 \
-    && update-alternatives --remove-all gcc \
-    && update-alternatives --remove-all g++ \
-    && update-alternatives --set gcc "/usr/bin/gcc-11" \
-    && update-alternatives --set g++ "/usr/bin/g++-11" \
-    && apt-get remove software-properties-common \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 10 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 10 \
+    && apt-get remove -y software-properties-common \
     && apt-get clean \
-    && apt-get autoremove \
-    && apt-get autoremove --purge
+    && apt-get autoremove -y \
+    && apt-get autoremove --purge -y

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,38 @@
+#
+# We base our image from the alpine light image
+FROM ubuntu:bionic-20230301
+
+#
+# Environment variables needed for the
+# build system
+ENV CONAN_USER_HOME="/conan"
+ENV TZ=Europe/London
+ENV DEBIAN_FRONTEND="noninteractive"
+
+#
+# Identify the maintainer of an image
+LABEL maintainer="matheusgarcia28@gmail.com"
+
+# install build dependencies 
+RUN apt-get update \
+    && apt-get install -y software-properties-common\
+    && add-apt-repository ppa:ubuntu-toolchain-r/test \
+    && apt-get install -y \
+    gcc-11 \
+    g++-11 \
+    make \
+    pkg-config \
+    python3 \
+    python3-pip \
+    && mkdir "/conan" \
+    && pip3 install --no-cache -q conan==2.0.1 \
+    && chmod -R 777 "/conan" \
+    && pip3 install --no-cache cmake==3.25.2 \
+    && update-alternatives --remove-all gcc \
+    && update-alternatives --remove-all g++ \
+    && update-alternatives --set gcc "/usr/bin/gcc-11" \
+    && update-alternatives --set g++ "/usr/bin/g++-11" \
+    && apt-get remove software-properties-common \
+    && apt-get clean \
+    && apt-get autoremove \
+    && apt-get autoremove --purge


### PR DESCRIPTION
This PR introduces a new docker image, so we no longer use the conan image.

The new docker image has the following features:

- gcc11
- CMake 3.25
- Conan 2.0
- half the size of the conan official image!
