### PR TITLE
Enable warnings as errors

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -36,7 +36,7 @@
             "hidden": true,
             "generator": "Ninja",
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic"
+                "CMAKE_CXX_FLAGS": "$env{CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -pedantic"
             }
         },
         {
@@ -44,7 +44,7 @@
             "hidden": true,
             "generator": "Ninja",
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CMAKE_CXX_FLAGS} /W4"
+                "CMAKE_CXX_FLAGS": "$env{CMAKE_CXX_FLAGS} /W4 /WX"
             }
         },
         {
@@ -52,7 +52,7 @@
             "hidden": true,
             "generator": "Unix Makefiles",
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic"
+                "CMAKE_CXX_FLAGS": "$env{CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -pedantic"
             }
         },
         {
@@ -60,7 +60,7 @@
             "hidden": true,
             "generator": "Visual Studio 17 2022",
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CMAKE_CXX_FLAGS} /W4"
+                "CMAKE_CXX_FLAGS": "$env{CMAKE_CXX_FLAGS} /W4 /WX"
             }
         },
         {
@@ -68,7 +68,7 @@
             "hidden": true,
             "generator": "Visual Studio 16 2019",
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CMAKE_CXX_FLAGS} /W4"
+                "CMAKE_CXX_FLAGS": "$env{CMAKE_CXX_FLAGS} /W4 /WX"
             }
         },
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -44,7 +44,7 @@
             "hidden": true,
             "generator": "Ninja",
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CMAKE_CXX_FLAGS} /W4 /WX"
+                "CMAKE_CXX_FLAGS": "$env{CMAKE_CXX_FLAGS} /W4 /WX /EHsc"
             }
         },
         {
@@ -60,7 +60,7 @@
             "hidden": true,
             "generator": "Visual Studio 17 2022",
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CMAKE_CXX_FLAGS} /W4 /WX"
+                "CMAKE_CXX_FLAGS": "$env{CMAKE_CXX_FLAGS} /W4 /WX /EHsc"
             }
         },
         {
@@ -68,7 +68,7 @@
             "hidden": true,
             "generator": "Visual Studio 16 2019",
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "$env{CMAKE_CXX_FLAGS} /W4 /WX"
+                "CMAKE_CXX_FLAGS": "$env{CMAKE_CXX_FLAGS} /W4 /WX /EHsc"
             }
         },
 

--- a/base64pp/base64pp.cpp
+++ b/base64pp/base64pp.cpp
@@ -165,7 +165,7 @@ std::optional<std::vector<std::uint8_t>> base64pp::decode(
     std::vector<std::uint8_t> decoded_bytes;
     decoded_bytes.reserve(((full_quadruples + 2) * 3) / 4);
 
-    for (auto i = 0; i < full_quadruples; ++i)
+    for (std::size_t i = 0; i < full_quadruples; ++i)
     {
         auto const quad  = encoded_str.substr(i * 4, 4);
         auto const bytes = decode_quad(quad[0], quad[1], quad[2], quad[3]);

--- a/base64pp/base64pp.cpp
+++ b/base64pp/base64pp.cpp
@@ -111,7 +111,7 @@ std::string base64pp::encode(std::span<std::uint8_t const> const input)
     std::string output;
     output.reserve((full_tripples + 2) * 4);
 
-    for (auto i = 0; i < full_tripples; ++i)
+    for (std::size_t i = 0; i < full_tripples; ++i)
     {
         auto const tripplet = input.subspan(i * 3, 3);
         auto const base64_chars =


### PR DESCRIPTION
Implements #18 .

This PR includes:

- [x] Changes to `CMakePresets.json` to add all Windows/Unix erro2warning flags.
- [x] Fixes to the code to enable building without errors. 