### PR TITLE
Adding Windows debug build to pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,7 @@ stages:
       - task: PublishPipelineArtifact@1
         inputs:
           targetPath: "$(Build.SourcesDirectory)/artifacts"
-          artifactName: 'BuildFiles'
+          artifactName: 'WinBuildFiles'
 
 - stage: 'docs'
   displayName: 'Build Documentation'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,27 @@ stages:
           targetPath: "$(Build.SourcesDirectory)/artifacts"
           artifactName: 'BuildFiles'
 
+  - job: 'build_win_x64'  
+    vmImage: 'windows-2022'
+    continueOnError: 'false'
+    steps:
+      - pwsh: .\scripts\helpers\conan-install.ps1
+        displayName: 'Installing all Conan dependencies'
+        workingDirectory: $(Build.SourcesDirectory)
+
+      - pwsh: |
+          .\scripts\build_win_x64.sh
+          New-Item -ItemType Direcotry -Force -Path "$(Build.SourcesDirectory)/artifacts"
+          7z a -ttar "$(Build.SourcesDirectory)/artifacts/build_win_64.tar"  "build/"
+          7z a -tgzip "$(Build.SourcesDirectory)/artifacts/build_win_64.tar.gz" "$(Build.SourcesDirectory)/artifacts/build_win_64.tar"
+        displayName: 'Compile Code & Tests'
+        workingDirectory: $(Build.SourcesDirectory)
+
+      - task: PublishPipelineArtifact@1
+        inputs:
+          targetPath: "$(Build.SourcesDirectory)/artifacts"
+          artifactName: 'BuildFiles'
+
 - stage: 'docs'
   displayName: 'Build Documentation'
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ stages:
 
       - pwsh: |
           .\scripts\build_win_x64.ps1
-          New-Item -ItemType Direcotry -Force -Path "$(Build.SourcesDirectory)/artifacts"
+          New-Item -ItemType Directory -Force -Path "$(Build.SourcesDirectory)/artifacts"
           7z a -ttar "$(Build.SourcesDirectory)/artifacts/build_win_64.tar"  "build/"
           7z a -tgzip "$(Build.SourcesDirectory)/artifacts/build_win_64.tar.gz" "$(Build.SourcesDirectory)/artifacts/build_win_64.tar"
         displayName: 'Compile Code & Tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,8 @@ stages:
           artifactName: 'BuildFiles'
 
   - job: 'build_win_x64'  
-    vmImage: 'windows-2022'
+    pool:
+      vmImage: 'windows-2022'
     continueOnError: 'false'
     steps:
       - pwsh: .\scripts\helpers\conan-install.ps1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ stages:
       vmImage: 'windows-2022'
     continueOnError: 'false'
     steps:
-      - pwsh: .\scripts\helpers\conan-install.ps1
+      - pwsh: .\scripts\helpers\conan-install.ps1 -BuildType Debug
         displayName: 'Installing all Conan dependencies'
         workingDirectory: $(Build.SourcesDirectory)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,6 +55,7 @@ stages:
           7z a -tgzip "$(Build.SourcesDirectory)/artifacts/build_win_64.tar.gz" "$(Build.SourcesDirectory)/artifacts/build_win_64.tar"
         displayName: 'Compile Code & Tests'
         workingDirectory: $(Build.SourcesDirectory)
+        failOnStderr: true
 
       - task: PublishPipelineArtifact@1
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,9 +50,12 @@ stages:
 
       - pwsh: |
           .\scripts\build_win_x64.ps1
+          if(!$?) { Exit $LASTEXITCODE }
           New-Item -ItemType Directory -Force -Path "$(Build.SourcesDirectory)/artifacts"
           7z a -ttar "$(Build.SourcesDirectory)/artifacts/build_win_64.tar"  "build/"
+          if(!$?) { Exit $LASTEXITCODE }
           7z a -tgzip "$(Build.SourcesDirectory)/artifacts/build_win_64.tar.gz" "$(Build.SourcesDirectory)/artifacts/build_win_64.tar"
+          if(!$?) { Exit $LASTEXITCODE }
         displayName: 'Compile Code & Tests'
         workingDirectory: $(Build.SourcesDirectory)
         failOnStderr: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ stages:
         workingDirectory: $(Build.SourcesDirectory)
 
       - pwsh: |
-          .\scripts\build_win_x64.sh
+          .\scripts\build_win_x64.ps1
           New-Item -ItemType Direcotry -Force -Path "$(Build.SourcesDirectory)/artifacts"
           7z a -ttar "$(Build.SourcesDirectory)/artifacts/build_win_64.tar"  "build/"
           7z a -tgzip "$(Build.SourcesDirectory)/artifacts/build_win_64.tar.gz" "$(Build.SourcesDirectory)/artifacts/build_win_64.tar"

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-gtest/1.10.0
+gtest/1.13.0
 
 [generators]
 CMakeDeps

--- a/scripts/build_win_x64.ps1
+++ b/scripts/build_win_x64.ps1
@@ -3,5 +3,5 @@ $ProjectDir = Split-Path -Parent $PSScriptRoot
 cmake "$ProjectDir" --preset="vs2022-deb"
 if(!$?) { Exit $LASTEXITCODE }
 
-cmake --build "$ProjectDir" --preset="vs2022-deb"
+cmake --build --preset="vs2022-deb"
 if(!$?) { Exit $LASTEXITCODE }

--- a/scripts/build_win_x64.ps1
+++ b/scripts/build_win_x64.ps1
@@ -1,6 +1,6 @@
 $ProjectDir = Split-Path -Parent $PSScriptRoot
 
-cmake "$ProjectDir" --preset="vs2022-deb" -DCMAKE_VERBOSE_MAKEFILE="True"
+cmake "$ProjectDir" --preset="vs2022-deb"
 if(!$?) { Exit $LASTEXITCODE }
 
 cmake --build --preset="vs2022-deb"

--- a/scripts/build_win_x64.ps1
+++ b/scripts/build_win_x64.ps1
@@ -3,5 +3,5 @@ $ProjectDir = Split-Path -Parent $PSScriptRoot
 cmake "$ProjectDir" --preset="vs2022-deb"
 if(!$?) { Exit $LASTEXITCODE }
 
-cmake --build "$ProjectDir" -- preset="vs2022-deb"
+cmake --build "$ProjectDir" --preset="vs2022-deb"
 if(!$?) { Exit $LASTEXITCODE }

--- a/scripts/build_win_x64.ps1
+++ b/scripts/build_win_x64.ps1
@@ -1,0 +1,7 @@
+$ProjectDir = Split-Path -Parent $PSScriptRoot
+
+cmake "$ProjectDir" --preset="vs2022-deb"
+if(!$?) { Exit $LASTEXITCODE }
+
+cmake --build "$ProjectDir" -- preset="vs2022-deb"
+if(!$?) { Exit $LASTEXITCODE }

--- a/scripts/build_win_x64.ps1
+++ b/scripts/build_win_x64.ps1
@@ -1,6 +1,6 @@
 $ProjectDir = Split-Path -Parent $PSScriptRoot
 
-cmake "$ProjectDir" --preset="vs2022-deb"
+cmake "$ProjectDir" --preset="vs2022-deb" -DCMAKE_VERBOSE_MAKEFILE="True"
 if(!$?) { Exit $LASTEXITCODE }
 
 cmake --build --preset="vs2022-deb"

--- a/scripts/build_x86-64.sh
+++ b/scripts/build_x86-64.sh
@@ -12,7 +12,7 @@ PROJECT_DIR="$(cd "${THIS_DIR}/.." && pwd)"
 
 
 # configure the project
-cmake --preset "unix-deb"
+cmake --preset "unix-deb" -DCMAKE_VERBOSE_MAKEFILE="True"
 
 cmake --build --preset "unix-deb" -j"$(nproc)"
   

--- a/scripts/build_x86-64.sh
+++ b/scripts/build_x86-64.sh
@@ -12,7 +12,7 @@ PROJECT_DIR="$(cd "${THIS_DIR}/.." && pwd)"
 
 
 # configure the project
-cmake --preset "unix-deb" -DCMAKE_VERBOSE_MAKEFILE="True"
+cmake --preset "unix-deb"
 
 cmake --build --preset "unix-deb" -j"$(nproc)"
   

--- a/scripts/helpers/conan-install.ps1
+++ b/scripts/helpers/conan-install.ps1
@@ -35,14 +35,14 @@ Set-Content -Path $ConanProfileFile -Value $ConanProfile
 Write-Output $ConanProfile
 
 # Install all dependencies
-$ProjectDir = Split-Path -Parent "$PSScriptRoot"
+$ProjectDir = (Get-Item "$PSScriptRoot").parent.parent.FullName
 $ConanOutputDir = "${ProjectDir}/conan/deb"
 if ($BuildType -eq "Release")
 {
     $ConanOutputDir = "${ProjectDir}/conan/rel"
 }
 
-conan install \
-  --output-folder="${ConanOutputDir}" \
-  --build=missing \
+conan install `
+  --output-folder="${ConanOutputDir}" `
+  --build=missing `
   "${ProjectDir}"

--- a/scripts/helpers/conan-install.ps1
+++ b/scripts/helpers/conan-install.ps1
@@ -46,3 +46,4 @@ conan install `
   --output-folder="${ConanOutputDir}" `
   --build=missing `
   "${ProjectDir}"
+if(!$?) { Exit $LASTEXITCODE }

--- a/scripts/helpers/conan-install.ps1
+++ b/scripts/helpers/conan-install.ps1
@@ -28,7 +28,7 @@ if(!$?) { Exit $LASTEXITCODE }
 # debug with MTd runtime on MSVC
 $ConanProfile = Get-Content -Path "$(conan profile path default)"
 if(!$?) { Exit $LASTEXITCODE }
-$ConanProfile = $ConanProfile -Replace "build_type=Debug", "build_type=Release"
+$ConanProfile = $ConanProfile -Replace "build_type=Release", "build_type=Debug"
 $ConanProfile = $ConanProfile -Replace "compiler.runtime=dynamic", "compiler.runtime=static"
 Write-Output "---- New conan profile -----"
 Set-Content -Path $ConanProfileFile -Value $ConanProfile

--- a/scripts/helpers/conan-install.ps1
+++ b/scripts/helpers/conan-install.ps1
@@ -1,20 +1,48 @@
+param (
+    [Parameter(Mandatory=$true)]
+    [ValidateSet("Debug","Release")]$BuildType
+)   
+
 # Need "if(!$?) { Exit $LASTEXITCODE }" after
 # every external command call as everything
 # needs to work for the build
 
 # Install conan with chocolatey
-choco install conan --version=2.0.1 /PathType="Machine"
-if(!$?) { Exit $LASTEXITCODE }
-RefreshEnv
+choco install conan --version=2.0.1 --installargs '/PathType:Machine' -y --no-progress
 if(!$?) { Exit $LASTEXITCODE }
 
-$ProjectDir = Split-Path -Parent $PSScriptRoot
+# Set this because refreshenv doesn't work
+# on the same powershell session
+if (-not(Get-Command conan -ErrorAction SilentlyContinue))
+{
+    New-Alias -Name conan -Value "$Env:ProgramFiles\Conan\conan\conan.exe"
+}
 
 conan profile detect --force
 if(!$?) { Exit $LASTEXITCODE }
 
+$ConanProfileFile = "$(conan profile path default)"
+if(!$?) { Exit $LASTEXITCODE }
+
+# Update the conan profiles to build for
+# debug with MTd runtime on MSVC
 $ConanProfile = Get-Content -Path "$(conan profile path default)"
 if(!$?) { Exit $LASTEXITCODE }
 $ConanProfile = $ConanProfile -Replace "build_type=Debug", "build_type=Release"
 $ConanProfile = $ConanProfile -Replace "compiler.runtime=dynamic", "compiler.runtime=static"
-Set-Content -Path $ConanProfile -Value $ConanProfile
+Write-Output "---- New conan profile -----"
+Set-Content -Path $ConanProfileFile -Value $ConanProfile
+Write-Output $ConanProfile
+
+# Install all dependencies
+$ProjectDir = Split-Path -Parent "$PSScriptRoot"
+$ConanOutputDir = "${ProjectDir}/conan/deb"
+if ($BuildType -eq "Release")
+{
+    $ConanOutputDir = "${ProjectDir}/conan/rel"
+}
+
+conan install \
+  --output-folder="${ConanOutputDir}" \
+  --build=missing \
+  "${ProjectDir}"

--- a/scripts/helpers/conan-install.ps1
+++ b/scripts/helpers/conan-install.ps1
@@ -1,0 +1,20 @@
+# Need "if(!$?) { Exit $LASTEXITCODE }" after
+# every external command call as everything
+# needs to work for the build
+
+# Install conan with chocolatey
+choco install conan --version=2.0.1 /PathType="Machine"
+if(!$?) { Exit $LASTEXITCODE }
+RefreshEnv
+if(!$?) { Exit $LASTEXITCODE }
+
+$ProjectDir = Split-Path -Parent $PSScriptRoot
+
+conan profile detect --force
+if(!$?) { Exit $LASTEXITCODE }
+
+$ConanProfile = Get-Content -Path "$(conan profile path default)"
+if(!$?) { Exit $LASTEXITCODE }
+$ConanProfile = $ConanProfile -Replace "build_type=Debug", "build_type=Release"
+$ConanProfile = $ConanProfile -Replace "compiler.runtime=dynamic", "compiler.runtime=static"
+Set-Content -Path $ConanProfile -Value $ConanProfile

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(CTest)
 
-find_package(GTest REQUIRED)
+find_package(GTest REQUIRED COMPONENTS gtest_main)
 
 add_executable(base64pp_tests base64pp_tests.cpp)
 target_link_libraries(base64pp_tests


### PR DESCRIPTION
Implements part of #27, i.e. adding the building to the pipeline.

Remarks:

1. Using the `windows-2022` runner, no container. 🪟 
2. Installing `conan` with chocolatey 🍫 💪 
3. Make `conan` available through alias, as `RefreshEnv` does not work in the same session.


Still todo:

- Add the unit tests to run on windows.