### PR TITLE
Unix compilation and tests with ASAN enabled

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -76,7 +76,7 @@
             "binaryDir": "${sourceDir}/build/unix-deb",
             "inherits": ["unix", "deb", "conan-deb"],
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS": "-O0 --coverage",
+                "CMAKE_CXX_FLAGS": "-O0 --coverage -g -fsanitize=address",
                 "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/unix-deb/install"
             }
         },


### PR DESCRIPTION
Implements part of #26. In this PR, we enable ASAN for the `unix-deb` build, also making the unit tests run with ASAN enabled.